### PR TITLE
Process embedded tx data in storage.

### DIFF
--- a/node/sync/src/controllers/serial.rs
+++ b/node/sync/src/controllers/serial.rs
@@ -204,6 +204,25 @@ impl SerialSyncController {
         }
     }
 
+    pub(crate) fn new_completed(
+        tx_seq: u64,
+        data_root: DataRoot,
+        num_chunks: usize,
+        ctx: Arc<SyncNetworkContext>,
+        store: Store,
+    ) -> Self {
+        SerialSyncController {
+            tx_seq,
+            data_root,
+            num_chunks,
+            next_chunk: 0,
+            state: SyncState::Completed,
+            peers: Default::default(),
+            ctx,
+            store,
+        }
+    }
+
     fn publish(&mut self, msg: PubsubMessage) {
         self.ctx.send(NetworkMessage::Publish {
             messages: vec![msg],

--- a/node/sync/src/service.rs
+++ b/node/sync/src/service.rs
@@ -352,13 +352,24 @@ impl SyncService {
                     }
                 };
 
-                let c = SerialSyncController::new(
-                    tx_seq,
-                    tx.data_merkle_root,
-                    num_chunks,
-                    self.ctx.clone(),
-                    self.store.clone(),
-                );
+                // TODO(ionian-dev): this is a silent failure, should we notify the caller?
+                let c = if self.store.check_tx_completed(tx_seq).await.unwrap_or(false) {
+                    SerialSyncController::new_completed(
+                        tx_seq,
+                        tx.data_merkle_root,
+                        num_chunks,
+                        self.ctx.clone(),
+                        self.store.clone(),
+                    )
+                } else {
+                    SerialSyncController::new(
+                        tx_seq,
+                        tx.data_merkle_root,
+                        num_chunks,
+                        self.ctx.clone(),
+                        self.store.clone(),
+                    )
+                };
 
                 entry.insert(c)
             }


### PR DESCRIPTION
It's not supported to get chunks with proof for the embedded data because this is not needed so far.