### PR TITLE
blockchain provider with retry

### DIFF
--- a/node/log_entry_sync/src/sync_manager/config.rs
+++ b/node/log_entry_sync/src/sync_manager/config.rs
@@ -14,6 +14,14 @@ pub struct LogSyncConfig {
     pub confirmation_block_count: u64,
     /// Maximum number of event logs to poll at a time.
     pub log_page_size: u64,
+
+    // blockchain provider retry params
+    // the number of retries after a connection times out
+    pub rate_limit_retries: u32,
+    // the nubmer of retries for rate limited responses
+    pub timeout_retries: u32,
+    // the duration to wait before retry, in ms
+    pub initial_backoff: u64,
 }
 
 #[derive(Clone)]
@@ -25,6 +33,7 @@ pub struct CacheConfig {
 }
 
 impl LogSyncConfig {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         rpc_endpoint_url: String,
         contract_address: ContractAddress,
@@ -32,6 +41,9 @@ impl LogSyncConfig {
         confirmation_block_count: u64,
         cache_config: CacheConfig,
         log_page_size: u64,
+        rate_limit_retries: u32,
+        timeout_retries: u32,
+        initial_backoff: u64,
     ) -> Self {
         Self {
             rpc_endpoint_url,
@@ -40,6 +52,9 @@ impl LogSyncConfig {
             start_block_number,
             confirmation_block_count,
             log_page_size,
+            rate_limit_retries,
+            timeout_retries,
+            initial_backoff,
         }
     }
 }

--- a/node/log_entry_sync/src/sync_manager/mod.rs
+++ b/node/log_entry_sync/src/sync_manager/mod.rs
@@ -67,6 +67,9 @@ impl LogSyncManager {
                         config.contract_address,
                         config.log_page_size,
                         config.confirmation_block_count,
+                        config.rate_limit_retries,
+                        config.timeout_retries,
+                        config.initial_backoff,
                     )
                     .await?;
                     let data_cache = DataCache::new(config.cache_config.clone());

--- a/node/log_entry_sync/src/sync_manager/mod.rs
+++ b/node/log_entry_sync/src/sync_manager/mod.rs
@@ -227,7 +227,6 @@ impl LogSyncManager {
                         }
                         e => {
                             error!("log put progress check rpc fails, e={:?}", e);
-                            bail!("log sync update progress error");
                         }
                     }
                 }

--- a/node/src/config/convert.rs
+++ b/node/src/config/convert.rs
@@ -86,6 +86,9 @@ impl IonianConfig {
             self.confirmation_block_count,
             cache_config,
             self.log_page_size,
+            self.rate_limit_retries,
+            self.timeout_retries,
+            self.initial_backoff,
         ))
     }
 

--- a/node/src/config/mod.rs
+++ b/node/src/config/mod.rs
@@ -24,6 +24,10 @@ build_config! {
     (max_cache_data_size, (usize), 100 * 1024 * 1024) // 100 MB
     (cache_tx_seq_ttl, (usize), 500)
 
+    (rate_limit_retries, (u32), 100)
+    (timeout_retries, (u32), 100)
+    (initial_backoff, (u64), 500)
+
     // rpc
     (rpc_enabled, (bool), true)
     (rpc_listen_address, (String), "127.0.0.1:5678".to_string())


### PR DESCRIPTION
- Use retry client in blockchain provider
- Do not exit watch thread when rpc error is met in handle_data()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ionian-web3-storage/ionian-rust/152)
<!-- Reviewable:end -->
